### PR TITLE
Implement Dialectica debate MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # Dialectica
+
+Dialectica is a lightweight MVP that orchestrates a structured debate between two AI agents (Proponent and Critic) and delivers a judged evaluation highlighting the strongest arguments and remaining trade-offs.
+
+## Features
+
+- Start a debate on any topic through a single input field.
+- Watch the debate unfold turn-by-turn with live status updates.
+- Each agent response includes citations backed by web search results.
+- Automatic judge evaluation summarizing the strongest pro and con points with outstanding trade-offs.
+- Copyable evaluation summary and full list of cited sources.
+
+## Prerequisites
+
+- [Node.js 18+](https://nodejs.org/) (for built-in `fetch` support).
+- A Google Gemini API key with access to the `gemini-2.5-flash-preview-05-20` model and web search grounding.
+
+## Getting Started
+
+1. Clone the repository and navigate into the project directory.
+2. Set the `GOOGLE_API_KEY` environment variable with your Gemini API key.
+3. (Optional) Set `DIALECTICA_TURNS` to change the number of turns per agent (defaults to 3).
+4. Start the server:
+
+```bash
+npm start
+```
+
+5. Open `http://localhost:3000` in your browser, enter a topic, and click **Start Debate**.
+
+The server streams debate events to the browser using Server-Sent Events (SSE), so you'll see each agent's response and the judge's evaluation as soon as they are generated.
+
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `GOOGLE_API_KEY` | Required. Gemini API key used to call the debate and judge models. |
+| `DIALECTICA_TURNS` | Optional. Number of turns per agent (default is 3). |
+| `PORT` | Optional. HTTP port for the server (defaults to 3000). |
+
+## Project Structure
+
+```
+├── public
+│   ├── app.js          # Frontend logic for managing debates and rendering UI
+│   ├── index.html      # Single-page application shell
+│   └── styles.css      # Minimalist styling
+├── src
+│   └── server.js       # Node HTTP server and debate orchestrator
+└── README.md
+```
+
+## Notes
+
+- The application requires outbound network access to the Gemini API. Ensure the environment where you run the server permits HTTPS requests to `generativelanguage.googleapis.com`.
+- The debate agents expect to cite their sources using placeholders like `[S1]` that are automatically translated into global citation numbers for display and judging.
+- The judge prompt reuses the debate transcript and shared citation list to ensure all conclusions remain grounded in the debate's evidence.
+
+## License
+
+This project is licensed under the ISC License.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dialectica",
+  "version": "1.0.0",
+  "description": "Dialectica debate orchestrator MVP",
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,293 @@
+const debateForm = document.getElementById('debate-form');
+const topicInput = document.getElementById('topic-input');
+const startButton = debateForm.querySelector('.primary-button');
+const errorMessageEl = document.getElementById('error-message');
+const debateSection = document.getElementById('debate-section');
+const statusEl = document.getElementById('debate-status');
+const turnList = document.getElementById('turn-list');
+const evaluationSection = document.getElementById('evaluation-section');
+const evaluationPro = document.getElementById('evaluation-pro');
+const evaluationCon = document.getElementById('evaluation-con');
+const evaluationTradeoffs = document.getElementById('evaluation-tradeoffs');
+const evaluationSourcesSection = document.getElementById('evaluation-sources');
+const evaluationSourceList = document.getElementById('evaluation-source-list');
+const copyButton = document.getElementById('copy-evaluation');
+const newDebateButton = document.getElementById('start-new-debate');
+
+let eventSource = null;
+let latestEvaluation = null;
+
+function resetInterface() {
+  hideError();
+  turnList.innerHTML = '';
+  setStatus('');
+  debateSection.classList.add('hidden');
+  evaluationSection.classList.add('hidden');
+  evaluationSourcesSection.classList.add('hidden');
+  evaluationSourceList.innerHTML = '';
+  evaluationPro.textContent = '';
+  evaluationCon.textContent = '';
+  evaluationTradeoffs.textContent = '';
+  latestEvaluation = null;
+  copyButton.disabled = true;
+  copyButton.textContent = 'Copy Evaluation';
+}
+
+function showError(message) {
+  errorMessageEl.textContent = message;
+}
+
+function hideError() {
+  errorMessageEl.textContent = '';
+}
+
+function setStatus(message) {
+  if (!message) {
+    statusEl.textContent = '';
+    statusEl.classList.add('hidden');
+    return;
+  }
+  statusEl.classList.remove('hidden');
+  statusEl.textContent = message;
+}
+
+function createTurnElement({ role, turn, argument, sources }) {
+  const container = document.createElement('article');
+  container.className = `debate-turn ${role}`;
+
+  const header = document.createElement('header');
+  const rolePill = document.createElement('span');
+  rolePill.className = `role-pill ${role}`;
+  rolePill.textContent = role === 'proponent' ? 'Proponent' : 'Critic';
+
+  const turnNumber = document.createElement('span');
+  turnNumber.className = 'turn-number';
+  turnNumber.textContent = `Round ${turn}`;
+
+  header.append(rolePill, turnNumber);
+
+  const argumentEl = document.createElement('p');
+  argumentEl.className = 'argument';
+  argumentEl.textContent = argument;
+
+  container.append(header, argumentEl);
+
+  if (Array.isArray(sources) && sources.length > 0) {
+    const sourcesTitle = document.createElement('span');
+    sourcesTitle.className = 'turn-sources-title';
+    sourcesTitle.textContent = 'Sources';
+
+    const list = document.createElement('ul');
+    list.className = 'source-list';
+
+    sources.forEach((source) => {
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = source.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = `[${source.number}] ${source.title}`;
+      item.appendChild(link);
+      list.appendChild(item);
+    });
+
+    container.append(sourcesTitle, list);
+  }
+
+  return container;
+}
+
+function appendTurn(turnData) {
+  debateSection.classList.remove('hidden');
+  const turnElement = createTurnElement(turnData);
+  turnList.appendChild(turnElement);
+  turnList.scrollTo({ top: turnList.scrollHeight, behavior: 'smooth' });
+}
+
+function handleEvaluation({ evaluation, sources }) {
+  latestEvaluation = evaluation;
+  evaluationSection.classList.remove('hidden');
+  evaluationPro.textContent = evaluation.strongestProArgument;
+  evaluationCon.textContent = evaluation.strongestConArgument;
+  evaluationTradeoffs.textContent = evaluation.unresolvedTradeOffs;
+
+  if (Array.isArray(sources) && sources.length > 0) {
+    evaluationSourcesSection.classList.remove('hidden');
+    evaluationSourceList.innerHTML = '';
+    sources.forEach((source) => {
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = source.url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = `[${source.number}] ${source.title}`;
+      item.appendChild(link);
+      evaluationSourceList.appendChild(item);
+    });
+  }
+
+  copyButton.disabled = false;
+  setStatus('Debate complete.');
+  enableForm();
+}
+
+function enableForm() {
+  topicInput.disabled = false;
+  startButton.disabled = false;
+  startButton.textContent = 'Start Debate';
+}
+
+function disableForm() {
+  topicInput.disabled = true;
+  startButton.disabled = true;
+  startButton.textContent = 'Debate Running...';
+}
+
+function closeEventSource() {
+  if (eventSource) {
+    eventSource.close();
+    eventSource = null;
+  }
+}
+
+function mapStatus(state, turn) {
+  switch (state) {
+    case 'starting':
+      return 'Setting up the debate...';
+    case 'proponent-thinking':
+      return `Proponent is preparing turn ${turn}...`;
+    case 'critic-thinking':
+      return `Critic is preparing turn ${turn}...`;
+    case 'judging':
+      return 'Judge is evaluating the debate...';
+    default:
+      return '';
+  }
+}
+
+function handleStatusEvent(data) {
+  const message = mapStatus(data.state, data.turn);
+  setStatus(message);
+}
+
+function startDebate(topic) {
+  closeEventSource();
+  resetInterface();
+  disableForm();
+  debateSection.classList.remove('hidden');
+  setStatus('Connecting to the debate orchestrator...');
+
+  const url = `/api/debate/stream?topic=${encodeURIComponent(topic)}`;
+  eventSource = new EventSource(url);
+
+  eventSource.addEventListener('status', (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      handleStatusEvent(data);
+    } catch (error) {
+      console.error('Failed to parse status event', error);
+    }
+  });
+
+  eventSource.addEventListener('turn', (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      appendTurn(data);
+    } catch (error) {
+      console.error('Failed to parse turn event', error);
+    }
+  });
+
+  eventSource.addEventListener('evaluation', (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      handleEvaluation(data);
+    } catch (error) {
+      console.error('Failed to parse evaluation event', error);
+      showError('Unable to read the judge\'s evaluation.');
+      enableForm();
+    }
+  });
+
+  eventSource.addEventListener('error', (event) => {
+    if (latestEvaluation) {
+      closeEventSource();
+      return;
+    }
+    if (event.data) {
+      try {
+        const data = JSON.parse(event.data);
+        showError(data.message || 'The debate encountered an error.');
+      } catch (parseError) {
+        showError('The debate encountered an unexpected error.');
+      }
+    } else {
+      showError('Connection lost. Please try starting the debate again.');
+    }
+    enableForm();
+    setStatus('');
+    closeEventSource();
+  });
+
+  eventSource.addEventListener('done', () => {
+    closeEventSource();
+  });
+}
+
+function buildEvaluationCopyText() {
+  if (!latestEvaluation) {
+    return '';
+  }
+  return [
+    'Strongest Pro Argument:',
+    latestEvaluation.strongestProArgument,
+    '',
+    'Strongest Con Argument:',
+    latestEvaluation.strongestConArgument,
+    '',
+    'Unresolved Trade-offs:',
+    latestEvaluation.unresolvedTradeOffs
+  ].join('\n');
+}
+
+debateForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const topic = topicInput.value.trim();
+  if (!topic) {
+    showError('Please enter a topic to debate.');
+    return;
+  }
+  hideError();
+  startDebate(topic);
+});
+
+copyButton.addEventListener('click', async () => {
+  if (!latestEvaluation) {
+    return;
+  }
+  const text = buildEvaluationCopyText();
+  try {
+    await navigator.clipboard.writeText(text);
+    copyButton.textContent = 'Copied!';
+    setTimeout(() => {
+      copyButton.textContent = 'Copy Evaluation';
+    }, 2000);
+  } catch (error) {
+    showError('Unable to copy the evaluation to your clipboard.');
+  }
+});
+
+newDebateButton.addEventListener('click', () => {
+  closeEventSource();
+  resetInterface();
+  enableForm();
+  topicInput.value = '';
+  topicInput.focus();
+});
+
+window.addEventListener('beforeunload', () => {
+  closeEventSource();
+});
+
+resetInterface();
+enableForm();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dialectica</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="header">
+      <div class="logo">Dialectica</div>
+    </header>
+    <main class="main">
+      <section class="input-section">
+        <form id="debate-form" class="debate-form" autocomplete="off">
+          <label class="visually-hidden" for="topic-input">Enter a topic to debate</label>
+          <input
+            id="topic-input"
+            type="text"
+            name="topic"
+            placeholder="Enter a topic, question, or idea to debate..."
+            maxlength="280"
+            required
+          />
+          <button type="submit" class="primary-button">Start Debate</button>
+        </form>
+        <p class="helper-text">
+          Dialectica will orchestrate a structured, evidence-based debate between two expert agents and deliver a judged
+          evaluation when the discussion ends.
+        </p>
+        <p id="error-message" class="error-message" role="alert" aria-live="assertive"></p>
+      </section>
+
+      <section id="debate-section" class="debate-section hidden" aria-live="polite">
+        <div class="section-heading">
+          <h2>Debate in Progress</h2>
+          <span id="debate-status" class="status-indicator hidden"></span>
+        </div>
+        <div id="turn-list" class="turn-list"></div>
+      </section>
+
+      <section id="evaluation-section" class="evaluation-section hidden" aria-live="polite">
+        <div class="section-heading">
+          <h2>Judge's Evaluation</h2>
+        </div>
+        <div id="evaluation-content" class="evaluation-content">
+          <article class="evaluation-item">
+            <h3>Strongest Pro Argument</h3>
+            <p id="evaluation-pro" class="evaluation-text"></p>
+          </article>
+          <article class="evaluation-item">
+            <h3>Strongest Con Argument</h3>
+            <p id="evaluation-con" class="evaluation-text"></p>
+          </article>
+          <article class="evaluation-item">
+            <h3>Unresolved Trade-offs</h3>
+            <p id="evaluation-tradeoffs" class="evaluation-text"></p>
+          </article>
+          <section id="evaluation-sources" class="evaluation-sources hidden">
+            <h4>All Sources Referenced</h4>
+            <ul id="evaluation-source-list"></ul>
+          </section>
+        </div>
+        <div class="evaluation-actions">
+          <button id="copy-evaluation" class="secondary-button" type="button">Copy Evaluation</button>
+          <button id="start-new-debate" class="primary-button" type="button">Start New Debate</button>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>Built for deep understanding through structured dialogue.</p>
+    </footer>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,338 @@
+:root {
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --border: #d7dce5;
+  --text-primary: #1c1f2b;
+  --text-secondary: #4f5b6d;
+  --accent: #3b82f6;
+  --accent-contrast: #ffffff;
+  --proponent: #ecfdf5;
+  --critic: #fef2f2;
+  --shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #e5edff 0%, #f5f7fb 45%, #f5f7fb 100%);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 24px 0;
+  text-align: center;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.main {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding-bottom: 64px;
+}
+
+.input-section,
+.debate-section,
+.evaluation-section {
+  background: var(--surface);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: var(--shadow);
+}
+
+.input-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.debate-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.debate-form input[type='text'] {
+  padding: 16px 20px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: #f9fbff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.debate-form input[type='text']:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.primary-button,
+.secondary-button {
+  cursor: pointer;
+  border: none;
+  border-radius: 12px;
+  padding: 14px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: var(--accent-contrast);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.secondary-button {
+  background: #eef2ff;
+  color: #312e81;
+}
+
+.primary-button:hover:not(:disabled),
+.secondary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
+}
+
+.helper-text {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.error-message {
+  min-height: 1.25rem;
+  margin: 0;
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.status-indicator {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-indicator::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+
+.turn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.debate-turn {
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.debate-turn.proponent {
+  background: var(--proponent);
+}
+
+.debate-turn.critic {
+  background: var(--critic);
+}
+
+.debate-turn header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.role-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.role-pill.proponent {
+  background: rgba(16, 185, 129, 0.2);
+  color: #047857;
+}
+
+.role-pill.critic {
+  background: rgba(239, 68, 68, 0.2);
+  color: #b91c1c;
+}
+
+.turn-number {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.argument {
+  margin: 0;
+  color: var(--text-primary);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.source-list {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--text-secondary);
+}
+
+.source-list li {
+  margin-bottom: 6px;
+  word-break: break-word;
+}
+
+.source-list a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.source-list a:hover {
+  text-decoration: underline;
+}
+
+.evaluation-content {
+  display: grid;
+  gap: 16px;
+}
+
+.evaluation-item {
+  padding: 20px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: #f8fafc;
+}
+
+.evaluation-item h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.evaluation-text {
+  margin: 0;
+  color: var(--text-primary);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.evaluation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.evaluation-sources h4 {
+  margin: 16px 0 8px;
+}
+
+.evaluation-sources ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--text-secondary);
+}
+
+.footer {
+  text-align: center;
+  padding: 32px 0 40px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .input-section,
+  .debate-section,
+  .evaluation-section {
+    padding: 24px;
+  }
+
+  .evaluation-item {
+    padding: 16px;
+  }
+}
+
+.turn-sources-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,464 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PUBLIC_DIR = path.join(__dirname, '../public');
+const MODEL_NAME = 'models/gemini-2.5-flash-preview-05-20';
+const GOOGLE_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+const DEFAULT_TURNS = Math.max(1, Number.parseInt(process.env.DIALECTICA_TURNS || '3', 10) || 3);
+const PORT = Number.parseInt(process.env.PORT || '3000', 10);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=UTF-8',
+  '.css': 'text/css; charset=UTF-8',
+  '.js': 'application/javascript; charset=UTF-8',
+  '.json': 'application/json; charset=UTF-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon'
+};
+
+function createServer() {
+  return http.createServer(async (req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return;
+    }
+
+    const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'GET' && requestUrl.pathname === '/api/debate/stream') {
+      handleDebateStream(req, res, requestUrl).catch((error) => {
+        console.error('Debate stream error:', error);
+      });
+      return;
+    }
+
+    serveStaticAsset(requestUrl, res);
+  });
+}
+
+function serveStaticAsset(url, res) {
+  const pathname = url.pathname === '/' ? '/index.html' : url.pathname;
+  const safePath = path.normalize(path.join(PUBLIC_DIR, pathname));
+
+  if (!safePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.readFile(safePath, (err, data) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+        return;
+      }
+      res.writeHead(500);
+      res.end('Internal Server Error');
+      return;
+    }
+
+    const ext = path.extname(safePath);
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+function formatTranscriptEntries(transcript) {
+  if (transcript.length === 0) {
+    return 'No turns have been taken yet.';
+  }
+
+  return transcript
+    .map((entry, index) => {
+      const speaker = entry.role === 'proponent' ? 'Proponent' : 'Critic';
+      return `${index + 1}. ${speaker}: ${entry.argument}`;
+    })
+    .join('\n');
+}
+
+function formatSourceReferenceList(sourcesByNumber) {
+  if (sourcesByNumber.size === 0) {
+    return 'No sources have been cited so far.';
+  }
+
+  const references = Array.from(sourcesByNumber.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([number, source]) => `[${number}] ${source.title} - ${source.url}`);
+
+  return references.join('\n');
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function handleDebateStream(req, res, requestUrl) {
+  const topic = (requestUrl.searchParams.get('topic') || '').trim();
+
+  if (!topic) {
+    sendSse(res, 'error', { message: 'A topic is required to start a debate.' });
+    res.end();
+    return;
+  }
+
+  if (topic.length > 280) {
+    sendSse(res, 'error', { message: 'Topic is too long. Please keep it under 280 characters.' });
+    res.end();
+    return;
+  }
+
+  const apiKey = process.env.GOOGLE_API_KEY || '';
+  if (!apiKey) {
+    sendSse(res, 'error', { message: 'Missing GOOGLE_API_KEY environment variable.' });
+    res.end();
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream; charset=UTF-8',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive'
+  });
+
+  sendSse(res, 'status', { state: 'starting' });
+
+  let aborted = false;
+  req.on('close', () => {
+    aborted = true;
+  });
+
+  const transcript = [];
+  const sourcesByNumber = new Map();
+  const sourceNumberForUrl = new Map();
+  let nextSourceNumber = 1;
+
+  try {
+    for (let turn = 1; turn <= DEFAULT_TURNS; turn += 1) {
+      if (aborted) {
+        return;
+      }
+
+      sendSse(res, 'status', { state: 'proponent-thinking', turn });
+
+      if (aborted) {
+        return;
+      }
+
+      const proponentResult = await callAgent({
+        apiKey,
+        topic,
+        role: 'proponent',
+        transcript,
+        turn,
+        totalTurns: DEFAULT_TURNS,
+        sourcesByNumber,
+        sourceNumberForUrl,
+        nextSourceNumber
+      });
+      nextSourceNumber = proponentResult.nextSourceNumber;
+      transcript.push({
+        role: 'proponent',
+        argument: proponentResult.argument
+      });
+      sendSse(res, 'turn', {
+        role: 'proponent',
+        turn,
+        argument: proponentResult.argument,
+        sources: proponentResult.sources
+      });
+
+      if (aborted) {
+        return;
+      }
+
+      sendSse(res, 'status', { state: 'critic-thinking', turn });
+
+      if (aborted) {
+        return;
+      }
+
+      const criticResult = await callAgent({
+        apiKey,
+        topic,
+        role: 'critic',
+        transcript,
+        turn,
+        totalTurns: DEFAULT_TURNS,
+        sourcesByNumber,
+        sourceNumberForUrl,
+        nextSourceNumber
+      });
+      nextSourceNumber = criticResult.nextSourceNumber;
+      transcript.push({
+        role: 'critic',
+        argument: criticResult.argument
+      });
+      sendSse(res, 'turn', {
+        role: 'critic',
+        turn,
+        argument: criticResult.argument,
+        sources: criticResult.sources
+      });
+    }
+
+    if (aborted) {
+      return;
+    }
+
+    sendSse(res, 'status', { state: 'judging' });
+
+    const evaluation = await callJudge({
+      apiKey,
+      topic,
+      transcript,
+      sourcesByNumber
+    });
+
+    sendSse(res, 'evaluation', {
+      evaluation,
+      sources: Array.from(sourcesByNumber.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([number, source]) => ({ number, ...source }))
+    });
+    sendSse(res, 'done', {});
+  } catch (error) {
+    console.error('Debate orchestration failed:', error);
+    sendSse(res, 'error', { message: error.message || 'An unexpected error occurred.' });
+  } finally {
+    res.end();
+  }
+}
+
+function sendSse(res, event, data) {
+  res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function proponentSystemPrompt(topic) {
+  return (
+    `You are a world-class expert on "${topic}". ` +
+    'Your objective is to argue passionately in favor of the topic. ' +
+    'Adopt an optimistic, constructive tone and build the strongest possible case grounded in verifiable evidence.'
+  );
+}
+
+function criticSystemPrompt(topic) {
+  return (
+    `You are a world-class critical thinker examining "${topic}". ` +
+    'Your objective is to highlight flaws, risks, counterarguments, and trade-offs. ' +
+    'Adopt a skeptical, analytical tone while grounding every point in verifiable evidence.'
+  );
+}
+
+function buildAgentUserPrompt({ topic, role, transcript, sourcesByNumber, turn, totalTurns }) {
+  const transcriptSummary = formatTranscriptEntries(transcript);
+  const sourcesSummary = formatSourceReferenceList(sourcesByNumber);
+  const roleDescription = role === 'proponent' ? 'supporting the idea' : 'critiquing the idea';
+  const turnDescriptor = turn === 1 ? 'opening statement' : turn === totalTurns ? 'final turn' : 'next turn';
+
+  return `Debate topic: "${topic}"\n\n` +
+    `Transcript so far (each entry already includes any citations):\n${transcriptSummary}\n\n` +
+    `Available citation reference numbers and their sources:\n${sourcesSummary}\n\n` +
+    `You are ${roleDescription}. This is your ${turnDescriptor} (turn ${turn} of ${totalTurns}).\n` +
+    'Requirements:\n' +
+    '- Reference prior points as needed to maintain a coherent debate.\n' +
+    '- Use the google_search tool to gather fresh evidence when introducing factual claims.\n' +
+    '- Cite evidence inside your argument using markers like [S1], [S2], etc.\n' +
+    '- Return ONLY valid JSON with exactly two properties: "argument" (string) and "sources" (array).\n' +
+    '- The "sources" array must include one object per citation marker with "title" and "url" fields.\n' +
+    '- If you reuse an existing source, include it again in the "sources" array with the same URL.\n' +
+    '- Each citation marker in "argument" must correspond to an item in "sources" (1-indexed, e.g., [S1]).\n' +
+    '- Keep the response under 250 words.\n' +
+    '- Do not include any explanatory text outside of the JSON.';
+}
+
+function parseAgentResponse(rawText) {
+  const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error('The model response did not include JSON output.');
+  }
+
+  try {
+    return JSON.parse(jsonMatch[0]);
+  } catch (error) {
+    throw new Error('Failed to parse the model response JSON.');
+  }
+}
+
+async function callAgent({
+  apiKey,
+  topic,
+  role,
+  transcript,
+  turn,
+  totalTurns,
+  sourcesByNumber,
+  sourceNumberForUrl,
+  nextSourceNumber
+}) {
+  const systemPrompt = role === 'proponent' ? proponentSystemPrompt(topic) : criticSystemPrompt(topic);
+  const userPrompt = buildAgentUserPrompt({ topic, role, transcript, sourcesByNumber, turn, totalTurns });
+  const rawResponse = await callGeminiApi({ apiKey, systemPrompt, userPrompt });
+  const parsed = parseAgentResponse(rawResponse);
+
+  if (typeof parsed.argument !== 'string' || !Array.isArray(parsed.sources)) {
+    throw new Error('Agent response JSON is missing required fields.');
+  }
+
+  if (parsed.sources.length === 0) {
+    throw new Error('Agent response must include at least one source.');
+  }
+
+  const messageSources = [];
+  let updatedArgument = parsed.argument;
+
+  parsed.sources.forEach((source, index) => {
+    if (!source || typeof source.title !== 'string' || typeof source.url !== 'string') {
+      throw new Error('Each source must include both "title" and "url" fields.');
+    }
+    const trimmedTitle = source.title.trim();
+    const trimmedUrl = source.url.trim();
+    if (!trimmedTitle || !trimmedUrl) {
+      throw new Error('Source title and URL cannot be empty.');
+    }
+
+    const marker = `[S${index + 1}]`;
+    const escapedMarker = escapeRegExp(marker);
+    const markerRegex = new RegExp(escapedMarker, 'g');
+    if (!markerRegex.test(parsed.argument)) {
+      throw new Error(`The marker ${marker} is missing from the argument.`);
+    }
+
+    let assignedNumber = sourceNumberForUrl.get(trimmedUrl);
+    if (!assignedNumber) {
+      assignedNumber = nextSourceNumber;
+      sourceNumberForUrl.set(trimmedUrl, assignedNumber);
+      sourcesByNumber.set(assignedNumber, { title: trimmedTitle, url: trimmedUrl });
+      nextSourceNumber += 1;
+    }
+
+    updatedArgument = updatedArgument.replace(new RegExp(escapedMarker, 'g'), `[${assignedNumber}]`);
+    messageSources.push({ number: assignedNumber, title: trimmedTitle, url: trimmedUrl });
+  });
+
+  const unmatchedMarkers = updatedArgument.match(/\[S\d+\]/g);
+  if (unmatchedMarkers) {
+    throw new Error(`Unmatched citation markers found: ${unmatchedMarkers.join(', ')}`);
+  }
+
+  return {
+    argument: updatedArgument.trim(),
+    sources: messageSources,
+    nextSourceNumber
+  };
+}
+
+async function callJudge({ apiKey, topic, transcript, sourcesByNumber }) {
+  const transcriptSummary = formatTranscriptEntries(transcript);
+  const sourcesSummary = formatSourceReferenceList(sourcesByNumber);
+
+  const userPrompt =
+    `You are an impartial and expert judge. The following is a debate transcript on "${topic}".\n\n` +
+    `Debate transcript (with citations already embedded):\n${transcriptSummary}\n\n` +
+    `Citation reference list:\n${sourcesSummary}\n\n` +
+    'Provide a structured evaluation containing three sections exactly: "Strongest Pro Argument", "Strongest Con Argument", and "Unresolved Trade-offs".\n' +
+    'Each section should be 1-3 sentences.\n' +
+    'Cite supporting evidence using the existing citation numbers in square brackets.\n' +
+    'Return ONLY valid JSON with properties "strongestProArgument", "strongestConArgument", and "unresolvedTradeOffs".';
+
+  const systemPrompt =
+    'You are an impartial judge summarizing debates. Highlight the most compelling point from each side and any unresolved tensions.';
+
+  const rawResponse = await callGeminiApi({ apiKey, systemPrompt, userPrompt });
+  const parsed = parseAgentResponse(rawResponse);
+
+  if (
+    typeof parsed.strongestProArgument !== 'string' ||
+    typeof parsed.strongestConArgument !== 'string' ||
+    typeof parsed.unresolvedTradeOffs !== 'string'
+  ) {
+    throw new Error('Judge response JSON is missing required fields.');
+  }
+
+  return {
+    strongestProArgument: parsed.strongestProArgument.trim(),
+    strongestConArgument: parsed.strongestConArgument.trim(),
+    unresolvedTradeOffs: parsed.unresolvedTradeOffs.trim()
+  };
+}
+
+async function callGeminiApi({ apiKey, systemPrompt, userPrompt }) {
+  const url = `${GOOGLE_API_BASE}/${MODEL_NAME}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+  const body = {
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: userPrompt }]
+      }
+    ],
+    // The PRD requires the google_search tool to be available to the agents.
+    tools: [{ googleSearch: {} }]
+  };
+
+  if (systemPrompt) {
+    body.systemInstruction = {
+      role: 'system',
+      parts: [{ text: systemPrompt }]
+    };
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8'
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    let errorMessage = `Gemini API request failed with status ${response.status}`;
+    try {
+      const errorData = await response.json();
+      if (errorData && errorData.error && errorData.error.message) {
+        errorMessage = `${errorMessage}: ${errorData.error.message}`;
+      }
+    } catch (parseError) {
+      // Ignore JSON parse errors for error responses.
+    }
+    throw new Error(errorMessage);
+  }
+
+  const data = await response.json();
+  const candidate = data?.candidates?.[0];
+  if (!candidate) {
+    throw new Error('Gemini API response did not include any candidates.');
+  }
+
+  const text = candidate?.content?.parts
+    ?.map((part) => part.text || '')
+    .join('')
+    .trim();
+
+  if (!text) {
+    throw new Error('Gemini API response did not contain text content.');
+  }
+
+  return text;
+}
+
+const server = createServer();
+
+server.listen(PORT, () => {
+  console.log(`Dialectica server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a lightweight Node HTTP server that streams Gemini-powered debate turns and judge output via SSE while managing shared citation numbering
- build a single-page interface that lets users launch debates, watch alternating turns with sources, and copy the final evaluation
- document setup steps, required environment variables, and project structure for running the Dialectica MVP

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cdd3f286008325a547b556e62f5734